### PR TITLE
Use sys.version_info instead of sys.version to obtain Python version

### DIFF
--- a/svc
+++ b/svc
@@ -9,7 +9,7 @@ import locale
 
 
 def to_unicode(input_str):
-    if sys.version < '3':
+    if sys.version_info < (3,):
         return unicode(input_str)
     else:
         return str(input_str)


### PR DESCRIPTION
The string `sys.version` should not be used as there is no guarantee that the version number is at the beginning of the string.
